### PR TITLE
Alpha 7

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,13 @@
 {
-  "extends": ["airbnb-typescript", "plugin:prettier/recommended", "plugin:jest/recommended"],
+  "extends": [
+    "airbnb-typescript",
+    "airbnb/hooks",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended",
+    "prettier/react",
+    "prettier/@typescript-eslint",
+    "plugin:jest/recommended"
+  ],
   "parserOptions": {
     "project": "./tsconfig.json"
   },
@@ -22,7 +30,9 @@
     "react/jsx-props-no-spreading": "off",
     "react/jsx-wrap-multilines": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/indent": "off",
+    "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/quotes": "off"
   },
   "overrides": [

--- a/@types/styled-system__should-forward-prop/index.d.ts
+++ b/@types/styled-system__should-forward-prop/index.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-shadow, @typescript-eslint/naming-convention */
+/* eslint-disable @typescript-eslint/no-shadow, @typescript-eslint/naming-convention */
 
 declare module '@styled-system/should-forward-prop' {
   type genericShouldForwardProp = (prop: string | number) => boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spicy-ui/core",
-  "version": "0.0.1-alpha.6",
+  "version": "0.0.1-alpha.7",
   "description": "A React component library to spice up your UI",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -51,12 +51,14 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
+    "@popperjs/core": "^2.5.3",
     "@styled-system/css": "^5.1.5",
     "@styled-system/should-forward-prop": "^5.1.5",
     "clsx": "^1.1.1",
     "deepmerge": "^4.2.2",
     "polished": "^4.0.3",
     "react-focus-lock": "^2.4.1",
+    "react-popper": "^2.2.3",
     "react-transition-group": "^4.4.1",
     "styled-normalize": "^8.0.7",
     "styled-system": "^5.1.5",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@styled-system/css": "^5.1.5",
     "@styled-system/should-forward-prop": "^5.1.5",
     "clsx": "^1.1.1",
+    "csstype": "^3.0.4",
     "deepmerge": "^4.2.2",
     "polished": "^4.0.3",
     "react-focus-lock": "^2.4.1",

--- a/src/Avatar/Avatar.stories.tsx
+++ b/src/Avatar/Avatar.stories.tsx
@@ -4,9 +4,9 @@ import { uid } from 'react-uid';
 import { Avatar } from '..';
 import { Stack } from '../Stack';
 
-const names = ['Dan Abrahmov', 'Ryan Florence', 'Resi Respati', 'Alex Gabites'];
+const names = ['Dan Abrahmov', 'Ryan Florence', 'Resi Respati', 'Alex Gabites', undefined, 'John Brown', 'Alan Sega'];
 
-const avatarSizes = ['xs', 'sm', 'md', 'lg'];
+const avatarSizes = ['xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl'];
 
 export default {
   title: 'Avatar',

--- a/src/Avatar/Avatar.stories.tsx
+++ b/src/Avatar/Avatar.stories.tsx
@@ -4,7 +4,7 @@ import { uid } from 'react-uid';
 import { Avatar } from '..';
 import { Stack } from '../Stack';
 
-const names = ['Dan Abrahmov', 'Ryan Florence', 'Resi Respati', 'Alex Gabites', undefined, 'John Brown', 'Alan Sega'];
+const names = ['Dan Abramov', 'Ryan Florence', 'Resi Respati', 'Alex Gabites', undefined, 'John Brown', 'Alan Sega'];
 
 const avatarSizes = ['xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl'];
 
@@ -17,7 +17,7 @@ export default {
 export const Simple = () => (
   <Avatar
     size={select<any>('size', avatarSizes, 'md')}
-    name={text('name', 'Dan Abrahmov')}
+    name={text('name', 'Dan Abramov')}
     src={text('src', 'https://bit.ly/dan-abramov')}
   />
 );

--- a/src/Avatar/Avatar.stories.tsx
+++ b/src/Avatar/Avatar.stories.tsx
@@ -1,0 +1,31 @@
+import { select, text, withKnobs } from '@storybook/addon-knobs';
+import * as React from 'react';
+import { uid } from 'react-uid';
+import { Avatar } from '..';
+import { Stack } from '../Stack';
+
+const names = ['Dan Abrahmov', 'Ryan Florence', 'Resi Respati', 'Alex Gabites'];
+
+const avatarSizes = ['xs', 'sm', 'md', 'lg'];
+
+export default {
+  title: 'Avatar',
+  component: Avatar,
+  decorators: [withKnobs],
+};
+
+export const Simple = () => (
+  <Avatar
+    size={select<any>('size', avatarSizes, 'md')}
+    name={text('name', 'Dan Abrahmov')}
+    src={text('src', 'https://bit.ly/dan-abramov')}
+  />
+);
+
+export const Sizes = () => (
+  <Stack orientation="horizontal" spacing={2}>
+    {avatarSizes.map((size, idx) => (
+      <Avatar key={uid(size, idx)} size={size as any} name={names[idx]} />
+    ))}
+  </Stack>
+);

--- a/src/Avatar/Avatar.tsx
+++ b/src/Avatar/Avatar.tsx
@@ -54,15 +54,13 @@ const AvatarWrapper = styled('div').withConfig<AvatarProps>({ shouldForwardProp 
   }),
 );
 
-const Avatar: React.FC<AvatarProps> = ({ name, src, ...rest }) => {
-  return (
-    <AvatarWrapper {...rest}>
-      {!name && !src && <Fallback />}
-      {name && !src && <Initials name={name} />}
-      {src && <Image src={src} />}
-    </AvatarWrapper>
-  );
-};
+const Avatar: React.FC<AvatarProps> = ({ name, src, ...rest }) => (
+  <AvatarWrapper {...rest}>
+    {!name && !src && <Fallback />}
+    {name && !src && <Initials name={name} />}
+    {src && <Image src={src} />}
+  </AvatarWrapper>
+);
 
 Avatar.defaultProps = {
   bg: 'gray.100',

--- a/src/Avatar/Avatar.tsx
+++ b/src/Avatar/Avatar.tsx
@@ -40,7 +40,7 @@ export interface AvatarProps extends Omit<ColorProps, 'color'> {
   size?: AvatarSize;
   /** Name of the user. */
   name?: string;
-  /* Url of avatar image. */
+  /** Url of avatar image. */
   src?: string;
 }
 

--- a/src/Avatar/Avatar.tsx
+++ b/src/Avatar/Avatar.tsx
@@ -1,0 +1,74 @@
+import { createShouldForwardProp, props } from '@styled-system/should-forward-prop';
+import * as React from 'react';
+import styled, { css } from 'styled-components';
+import { color, ColorProps } from 'styled-system';
+import { Box } from '../Box';
+import { baseStyle, size, withColorMode } from '../util';
+
+const Fallback: React.FC = () => (
+  <Box width="full" height="full">
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+      <circle cx="12" cy="7" r="4" />
+    </svg>
+  </Box>
+);
+
+const Initials: React.FC<{ name: string }> = ({ name }) => (
+  <span>
+    {name
+      .split(' ')
+      .map((part, i) => (i < 2 ? part.charAt(0) : undefined))
+      .filter((part) => !!part)}
+  </span>
+);
+
+const Image: React.FC<{ src?: string }> = ({ src }) => <Box as="img" src={src} maxWidth="100%" />;
+
+export type AvatarSize = 'xs' | 'sm' | 'md' | 'lg';
+
+export interface AvatarProps extends Omit<ColorProps, 'color'> {
+  /** Size of the avatar. */
+  size?: AvatarSize;
+  /** Name of the user. */
+  name?: string;
+  /* Url of avatar image. */
+  src?: string;
+}
+
+const shouldForwardProp = createShouldForwardProp([...props]);
+
+const AvatarWrapper = styled('div').withConfig<AvatarProps>({ shouldForwardProp })((p) =>
+  css({
+    ...withColorMode(baseStyle('components.Avatar'))(p),
+    ...withColorMode(size('components.Avatar'))(p),
+    ...color(p),
+  }),
+);
+
+const Avatar: React.FC<AvatarProps> = ({ name, src, ...rest }) => {
+  return (
+    <AvatarWrapper {...rest}>
+      {!name && !src && <Fallback />}
+      {name && !src && <Initials name={name} />}
+      {src && <Image src={src} />}
+    </AvatarWrapper>
+  );
+};
+
+Avatar.defaultProps = {
+  bg: 'gray.100',
+  size: 'md',
+};
+
+Avatar.displayName = 'Avatar';
+
+export { Avatar };

--- a/src/Avatar/Avatar.tsx
+++ b/src/Avatar/Avatar.tsx
@@ -33,7 +33,7 @@ const Initials: React.FC<{ name: string }> = ({ name }) => (
 
 const Image: React.FC<{ src?: string }> = ({ src }) => <Box as="img" src={src} maxWidth="100%" />;
 
-export type AvatarSize = 'xs' | 'sm' | 'md' | 'lg';
+export type AvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl';
 
 export interface AvatarProps extends Omit<ColorProps, 'color'> {
   /** Size of the avatar. */

--- a/src/Avatar/index.ts
+++ b/src/Avatar/index.ts
@@ -1,0 +1,1 @@
+export * from './Avatar';

--- a/src/Box/Box.tsx
+++ b/src/Box/Box.tsx
@@ -1,4 +1,5 @@
 import shouldForwardProp from '@styled-system/should-forward-prop';
+import * as CSS from 'csstype';
 import styled from 'styled-components';
 import {
   background,
@@ -16,6 +17,8 @@ import {
   LayoutProps,
   position,
   PositionProps,
+  RequiredTheme,
+  ResponsiveValue,
   shadow,
   ShadowProps,
   space,
@@ -26,7 +29,7 @@ import {
 
 export interface BoxProps
   extends LayoutProps,
-    PositionProps,
+    Omit<PositionProps, 'zIndex'>,
     FlexboxProps,
     GridProps,
     SpaceProps,
@@ -34,7 +37,15 @@ export interface BoxProps
     Omit<ColorProps, 'color'>,
     TypographyProps,
     BorderProps,
-    ShadowProps {}
+    ShadowProps {
+  /**
+   * The z-index CSS property sets the z-order of a positioned element and its descendants or
+   * flex items. Overlapping elements with a larger z-index cover those with a smaller one.
+   *
+   * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/z-index)
+   */
+  zIndex?: ResponsiveValue<CSS.Property.ZIndex | string, RequiredTheme>;
+}
 
 export const boxMixin = compose(layout, position, flexbox, grid, space, background, color, typography, border, shadow);
 

--- a/src/Drawer/Drawer.stories.tsx
+++ b/src/Drawer/Drawer.stories.tsx
@@ -19,8 +19,8 @@ export const Simple = () => (
     anchor={select('anchor', drawerAnchors, 'right')}
     size={select('size', drawerSizes, 'xs')}
     onClose={action('onClose')}
-    closeOnEsc={boolean('disable escape key listener', false)}
-    closeOnOverlayClick={boolean('disable overlay click', false)}
+    closeOnEsc={boolean('enable escape key listener', false)}
+    closeOnOverlayClick={boolean('enable overlay click', false)}
     disableFocusTrap={boolean('disable drawer focus trap', false)}
   >
     <Box>
@@ -41,8 +41,8 @@ export const Toggle = () => {
         anchor={select('anchor', drawerAnchors, 'right')}
         size={select('size', drawerSizes, 'xs')}
         onClose={() => setIsOpen(false)}
-        closeOnEsc={boolean('disable escape key listener', false)}
-        closeOnOverlayClick={boolean('disable overlay click', false)}
+        closeOnEsc={boolean('enable escape key listener', false)}
+        closeOnOverlayClick={boolean('enable overlay click', false)}
         disableFocusTrap={boolean('disable drawer focus trap', false)}
       >
         Drawer

--- a/src/Drawer/Drawer.stories.tsx
+++ b/src/Drawer/Drawer.stories.tsx
@@ -19,8 +19,8 @@ export const Simple = () => (
     anchor={select('anchor', drawerAnchors, 'right')}
     size={select('size', drawerSizes, 'xs')}
     onClose={action('onClose')}
-    disableOverlayClick={boolean('disable overlay click', false)}
-    disableListeners={boolean('disable escape key listener', false)}
+    closeOnEsc={boolean('disable escape key listener', false)}
+    closeOnOverlayClick={boolean('disable overlay click', false)}
     disableFocusTrap={boolean('disable drawer focus trap', false)}
   >
     <Box>
@@ -41,8 +41,8 @@ export const Toggle = () => {
         anchor={select('anchor', drawerAnchors, 'right')}
         size={select('size', drawerSizes, 'xs')}
         onClose={() => setIsOpen(false)}
-        disableOverlayClick={boolean('disable overlay click', false)}
-        disableListeners={boolean('disable escape key listener', false)}
+        closeOnEsc={boolean('disable escape key listener', false)}
+        closeOnOverlayClick={boolean('disable overlay click', false)}
         disableFocusTrap={boolean('disable drawer focus trap', false)}
       >
         Drawer

--- a/src/Drawer/Drawer.tsx
+++ b/src/Drawer/Drawer.tsx
@@ -74,6 +74,8 @@ const getAnchor = (anchor: DrawerAnchor) => {
 export interface DrawerProps extends Omit<ColorProps, 'color'> {
   /** Whether the drawer is open or not. */
   isOpen: boolean;
+  /** Callback method to close the drawer. */
+  onClose?: () => void;
   /** Side that the drawer will appear from. */
   anchor?: DrawerAnchor;
   /** Size of the drawer. */
@@ -84,8 +86,6 @@ export interface DrawerProps extends Omit<ColorProps, 'color'> {
   disableListeners?: boolean;
   /** Set to `true` to disable the drawers focus trap behaviour. */
   disableFocusTrap?: boolean;
-  /** Callback method run when the Close button is clicked. */
-  onClose?: () => void;
 }
 
 const Drawer: React.FC<DrawerProps> = ({

--- a/src/Drawer/Drawer.tsx
+++ b/src/Drawer/Drawer.tsx
@@ -80,10 +80,10 @@ export interface DrawerProps extends Omit<ColorProps, 'color'> {
   anchor?: DrawerAnchor;
   /** Size of the drawer. */
   size?: string;
-  /** Set to `true` to disable closing the drawer by clicking the overlay. */
-  disableOverlayClick?: boolean;
-  /** Set to `true` to disable closing the drawer by pushing the escape key. */
-  disableListeners?: boolean;
+  /** Set to `true` to enable closing the drawer by pushing the `Esc` key. */
+  closeOnEsc?: boolean;
+  /** Set to `true` to enable closing the modal by clicking the overlay. */
+  closeOnOverlayClick?: boolean;
   /** Set to `true` to disable the drawers focus trap behaviour. */
   disableFocusTrap?: boolean;
 }
@@ -93,30 +93,30 @@ const Drawer: React.FC<DrawerProps> = ({
   isOpen,
   anchor = 'right',
   size = 'xs',
-  disableOverlayClick,
-  disableListeners,
+  closeOnEsc,
+  closeOnOverlayClick,
   disableFocusTrap,
   onClose,
   ...other
 }) => {
   useKeyPress('Escape', () => {
-    if (isOpen && !disableListeners && onClose) {
+    if (isOpen && !closeOnEsc && onClose) {
       onClose();
     }
   });
 
   const handleOverlayClick = React.useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
-      // Prevent clicking inside the dialog exiting it
+      // Prevent clicks inside the drawer from closing it
       if (e.target !== e.currentTarget) {
         return;
       }
 
-      if (!disableOverlayClick && onClose) {
+      if (closeOnOverlayClick && onClose) {
         onClose();
       }
     },
-    [disableOverlayClick, onClose],
+    [closeOnOverlayClick, onClose],
   );
 
   React.useEffect(() => {

--- a/src/Heading/Heading.stories.tsx
+++ b/src/Heading/Heading.stories.tsx
@@ -16,7 +16,7 @@ export const Simple = () => <Heading variant={select('variant', variants, 'h2')}
 export const AllVariants = () => (
   <Stack spacing="4">
     {variants.map((variant, idx) => (
-      <Heading key={uid(variant, idx)} variant={variant}>
+      <Heading key={uid(variant, idx)} as={variant as any} variant={variant}>
         {variant}: Heading
       </Heading>
     ))}

--- a/src/Menu/Menu.stories.tsx
+++ b/src/Menu/Menu.stories.tsx
@@ -1,7 +1,7 @@
 import { withKnobs } from '@storybook/addon-knobs';
 import * as React from 'react';
 import { uid } from 'react-uid';
-import { Button, Flex, Menu, MenuDivider, MenuHeader, MenuItem, Popover, Text, Box } from '..';
+import { Box, Button, Flex, Menu, MenuDivider, MenuHeader, MenuItem, Popover, Text } from '..';
 
 export default {
   title: 'Menu',
@@ -127,5 +127,3 @@ export const WithCustomItems = () => (
     </Menu>
   </Box>
 );
-
-// can you popper off a popper element...? 🤔

--- a/src/Menu/Menu.stories.tsx
+++ b/src/Menu/Menu.stories.tsx
@@ -1,0 +1,131 @@
+import { withKnobs } from '@storybook/addon-knobs';
+import * as React from 'react';
+import { uid } from 'react-uid';
+import { Button, Flex, Menu, MenuDivider, MenuHeader, MenuItem, Popover, Text, Box } from '..';
+
+export default {
+  title: 'Menu',
+  component: Menu,
+  subcomponents: {
+    MenuDivider,
+    MenuHeader,
+    MenuItem,
+  },
+  decorators: [withKnobs],
+};
+
+export const Simple = () => (
+  <Box maxWidth="56">
+    <Menu>
+      <MenuItem>View</MenuItem>
+      <MenuItem>Share</MenuItem>
+      <MenuItem>Download</MenuItem>
+      <MenuItem>Delete</MenuItem>
+    </Menu>
+  </Box>
+);
+
+export const WithDividers = () => (
+  <Box maxWidth="56">
+    <Menu>
+      <MenuItem>Cut</MenuItem>
+      <MenuItem>Copy</MenuItem>
+      <MenuItem>Paste</MenuItem>
+      <MenuDivider />
+      <MenuItem>Delete</MenuItem>
+      <MenuItem>Rename</MenuItem>
+      <MenuDivider />
+      <MenuItem>Properties</MenuItem>
+    </Menu>
+  </Box>
+);
+
+export const WithHeaders = () => (
+  <Box maxWidth="56">
+    <Menu>
+      <MenuHeader>Sort by</MenuHeader>
+      <MenuItem>Alphabetical</MenuItem>
+      <MenuItem>Date created</MenuItem>
+      <MenuItem>Last viewed</MenuItem>
+      <MenuDivider />
+      <MenuHeader>Order</MenuHeader>
+      <MenuItem>Ascending</MenuItem>
+      <MenuItem>Descending</MenuItem>
+    </Menu>
+  </Box>
+);
+
+export const WithPopover = () => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  return (
+    <Popover
+      isOpen={isOpen}
+      onClose={() => setIsOpen(false)}
+      trigger={<Button onClick={() => setIsOpen((prev) => !prev)}>Menu Trigger</Button>}
+      offset={[0, 8]}
+    >
+      <Menu>
+        <MenuItem>Profile</MenuItem>
+        <MenuItem>Friends</MenuItem>
+        <MenuDivider />
+        <MenuItem>Settings</MenuItem>
+        <MenuItem>Sign out</MenuItem>
+      </Menu>
+    </Popover>
+  );
+};
+
+export const WithCustomItems = () => (
+  <Box maxWidth="56">
+    <Menu>
+      <MenuItem>
+        <Flex minHeight="16" direction="column" justify="center" flex="1 1 auto">
+          <Text>Signed in as</Text>
+          <Text fontWeight="semibold">John Brown</Text>
+        </Flex>
+      </MenuItem>
+      <MenuDivider />
+      <MenuItem>
+        <Text mr="auto">Your profile</Text>
+        <span>📛</span>
+      </MenuItem>
+      <MenuItem>
+        <Text mr="auto">Your repositories</Text>
+        <span>🗃️</span>
+      </MenuItem>
+      <MenuItem>
+        <Text mr="auto">Your stars</Text>
+        <span>⭐</span>
+      </MenuItem>
+      <MenuDivider />
+      <MenuItem>
+        <Text mr="auto">Settings</Text>
+        <span>⚙️</span>
+      </MenuItem>
+      <MenuItem>
+        <Text mr="auto">Sign out</Text>
+        <span>🏃‍♂️</span>
+      </MenuItem>
+    </Menu>
+    <Box mt="8" />
+    <Menu>
+      {[
+        { text: 'Cut', kdb: 'Ctrl + X' },
+        { text: 'Copy', kdb: 'Ctrl + C' },
+        { text: 'Paste', kdb: 'Ctrl + V' },
+      ].map((item, idx) => (
+        <MenuItem key={uid(item, idx)}>
+          <Flex direction="row" align="center" flex="1 1 auto">
+            <Text mr="auto">{item.text}</Text>
+            <Text color="gray.500" fontSize="sm">
+              {item.kdb}
+            </Text>
+          </Flex>
+        </MenuItem>
+      ))}
+    </Menu>
+  </Box>
+);
+
+// can you popper off a popper element...? 🤔

--- a/src/Menu/Menu.tsx
+++ b/src/Menu/Menu.tsx
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+import { Box } from '../Box';
+import { baseStyle, withColorMode } from '../util';
+
+export const Menu = styled(Box)`
+  ${withColorMode(baseStyle('components.Menu'))}
+`;
+
+export const MenuItem = styled(Box)`
+  ${withColorMode(baseStyle('components.MenuItem'))}
+`;
+
+export const MenuDivider = styled('div')`
+  ${withColorMode(baseStyle('components.MenuDivider'))}
+`;
+
+export const MenuHeader = styled(Box)`
+  ${withColorMode(baseStyle('components.MenuHeader'))}
+`;

--- a/src/Menu/index.ts
+++ b/src/Menu/index.ts
@@ -1,0 +1,1 @@
+export * from './Menu';

--- a/src/Modal/Modal.stories.tsx
+++ b/src/Modal/Modal.stories.tsx
@@ -16,8 +16,8 @@ export const Simple = () => (
     isOpen
     onClose={action('onClose')}
     size={select('size', modalSizes, 'sm')}
-    disableOverlayClick={boolean('disable overlay click', false)}
-    disableListeners={boolean('disable escape key listener', false)}
+    closeOnEsc={boolean('disable escape key listener', false)}
+    closeOnOverlayClick={boolean('disable overlay click', false)}
     disableFocusTrap={boolean('disable modal focus trap', false)}
   >
     Modal
@@ -34,8 +34,8 @@ export const Toggle = () => {
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
         size={select('size', modalSizes, 'sm')}
-        disableOverlayClick={boolean('disable overlay click', false)}
-        disableListeners={boolean('disable escape key listener', false)}
+        closeOnEsc={boolean('disable escape key listener', false)}
+        closeOnOverlayClick={boolean('disable overlay click', false)}
         disableFocusTrap={boolean('disable modal focus trap', false)}
       >
         Modal

--- a/src/Modal/Modal.stories.tsx
+++ b/src/Modal/Modal.stories.tsx
@@ -16,8 +16,8 @@ export const Simple = () => (
     isOpen
     onClose={action('onClose')}
     size={select('size', modalSizes, 'sm')}
-    closeOnEsc={boolean('disable escape key listener', false)}
-    closeOnOverlayClick={boolean('disable overlay click', false)}
+    closeOnEsc={boolean('enable escape key listener', false)}
+    closeOnOverlayClick={boolean('enable overlay click', false)}
     disableFocusTrap={boolean('disable modal focus trap', false)}
   >
     Modal
@@ -34,8 +34,8 @@ export const Toggle = () => {
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
         size={select('size', modalSizes, 'sm')}
-        closeOnEsc={boolean('disable escape key listener', false)}
-        closeOnOverlayClick={boolean('disable overlay click', false)}
+        closeOnEsc={boolean('enable escape key listener', false)}
+        closeOnOverlayClick={boolean('enable overlay click', false)}
         disableFocusTrap={boolean('disable modal focus trap', false)}
       >
         Modal

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -45,6 +45,8 @@ const ModalWrapper = styled('div').withConfig<ModalWrapperProps>({ shouldForward
 export interface ModalProps extends Omit<ColorProps, 'color'> {
   /** Whether the modal is open or not. */
   isOpen: boolean;
+  /** Callback method to close the modal. */
+  onClose?: () => void;
   /** Set max size of the modal */
   size?: string;
   /** Set to `true` to disable closing the modal by clicking the overlay. */
@@ -53,8 +55,6 @@ export interface ModalProps extends Omit<ColorProps, 'color'> {
   disableListeners?: boolean;
   /** Set to `true` to disable the modals focus trap behaviour. */
   disableFocusTrap?: boolean;
-  /** Callback method run when the close button is clicked. */
-  onClose?: () => void;
 }
 
 const Modal: React.FC<ModalProps> = ({

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -47,12 +47,12 @@ export interface ModalProps extends Omit<ColorProps, 'color'> {
   isOpen: boolean;
   /** Callback method to close the modal. */
   onClose?: () => void;
-  /** Set max size of the modal */
+  /** Set max size of the modal. */
   size?: string;
-  /** Set to `true` to disable closing the modal by clicking the overlay. */
-  disableOverlayClick?: boolean;
-  /** Set to `true` to disable closing the modal by pushing the escape key. */
-  disableListeners?: boolean;
+  /** Set to `true` to enable closing the modal by pushing the `Esc` key. */
+  closeOnEsc?: boolean;
+  /** Set to `true` to enable closing the modal by clicking the overlay. */
+  closeOnOverlayClick?: boolean;
   /** Set to `true` to disable the modals focus trap behaviour. */
   disableFocusTrap?: boolean;
 }
@@ -61,30 +61,30 @@ const Modal: React.FC<ModalProps> = ({
   children,
   size = 'md',
   isOpen,
-  disableOverlayClick,
-  disableListeners,
+  closeOnEsc,
+  closeOnOverlayClick,
   disableFocusTrap,
   onClose,
   ...other
 }) => {
   useKeyPress('Escape', () => {
-    if (isOpen && !disableListeners && onClose) {
+    if (isOpen && closeOnEsc && onClose) {
       onClose();
     }
   });
 
   const handleOverlayClick = React.useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
-      // Prevent clicking to exit inside the dialog
+      // Prevent clicks inside the modal from closing it
       if (e.target !== e.currentTarget) {
         return;
       }
 
-      if (!disableOverlayClick && onClose) {
+      if (closeOnOverlayClick && onClose) {
         onClose();
       }
     },
-    [disableOverlayClick, onClose],
+    [closeOnOverlayClick, onClose],
   );
 
   React.useEffect(() => {

--- a/src/Overlay/Overlay.tsx
+++ b/src/Overlay/Overlay.tsx
@@ -8,6 +8,7 @@ import { useTheme } from '../ThemeProvider';
 import { baseStyle, withColorMode } from '../util';
 import { OverlayIn, OverlayOut } from './keyframes';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface BackdropProps {}
 
 const Backdrop = styled('div').withConfig<BackdropProps>({ shouldForwardProp })(

--- a/src/Popover/Popover.stories.tsx
+++ b/src/Popover/Popover.stories.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { Box } from '../Box';
+import { Button } from '../Button';
+import { Popover } from './Popover';
+
+export default {
+  title: 'Popover',
+  component: Popover,
+};
+
+export const Simple = () => (
+  <Popover trigger={<Button>Toggle Popover</Button>}>
+    <Box mt={2} bg="white" boxShadow="sm" borderRadius="sm">
+      Hello world
+    </Box>
+  </Popover>
+);

--- a/src/Popover/Popover.stories.tsx
+++ b/src/Popover/Popover.stories.tsx
@@ -1,17 +1,52 @@
+import { Placement } from '@popperjs/core';
+import { array, boolean, select, withKnobs } from '@storybook/addon-knobs';
 import * as React from 'react';
 import { Box } from '../Box';
 import { Button } from '../Button';
-import { Popover } from './Popover';
+import { Popover, Offset } from './Popover';
+
+const placements: Placement[] = [
+  'auto',
+  'auto-end',
+  'auto-start',
+  'bottom',
+  'bottom-end',
+  'bottom-start',
+  'left',
+  'left-end',
+  'left-start',
+  'right',
+  'right-end',
+  'right-start',
+  'top',
+  'top-end',
+  'top-start',
+];
 
 export default {
   title: 'Popover',
   component: Popover,
+  decorators: [withKnobs],
 };
 
-export const Simple = () => (
-  <Popover trigger={<Button>Toggle Popover</Button>}>
-    <Box mt={2} bg="white" boxShadow="sm" borderRadius="sm">
-      Hello world
-    </Box>
-  </Popover>
-);
+export const Simple = () => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  return (
+    <Popover
+      trigger={<Button onClick={() => setIsOpen((prev) => !prev)}>Toggle Popover</Button>}
+      isOpen={isOpen}
+      onClose={() => setIsOpen(false)}
+      closeOnBlur={boolean('close on blur', true)}
+      closeOnEsc={boolean('close on escape key', false)}
+      closeOnInnerClick={boolean('close on inner click', false)}
+      closeOnOuterClick={boolean('close on outer click', false)}
+      placement={select('placement', placements, 'bottom-start')}
+      offset={array('offset', ['0', '10'], ',').map((n) => Number.parseInt(n, 10)) as Offset}
+    >
+      <Box p={2} bg="white" boxShadow="sm" borderRadius="sm">
+        Hello world
+      </Box>
+    </Popover>
+  );
+};

--- a/src/Popover/Popover.tsx
+++ b/src/Popover/Popover.tsx
@@ -19,9 +19,9 @@ export interface PopoverProps {
   closeOnBlur?: boolean;
   /** Set to `true` to enable closing of the popover by pushing the `Esc` key. */
   closeOnEsc?: boolean;
-  /** Set to `true` to enable closing of the popover when a click is made inside the popover. */
+  /** Set to `true` to enable closing of the popover by clicking inside the popover. */
   closeOnInnerClick?: boolean;
-  /** Set to `true` to enable closing of the popover when a click is made outside the popover. */
+  /** Set to `true` to enable closing of the popover by clicking outside the popover. */
   closeOnOuterClick?: boolean;
   /** Position of the popover. */
   placement?: Placement;
@@ -36,11 +36,11 @@ const Popover: React.FC<PopoverProps> = ({
   children,
   isOpen,
   onClose,
-  closeOnBlur,
-  closeOnEsc,
-  closeOnInnerClick,
-  closeOnOuterClick,
-  placement,
+  closeOnBlur = true,
+  closeOnEsc = false,
+  closeOnInnerClick = false,
+  closeOnOuterClick = false,
+  placement = 'bottom-start',
   offset,
   modifiers = [],
 }) => {
@@ -103,15 +103,6 @@ const Popover: React.FC<PopoverProps> = ({
       </Box>
     </>
   );
-};
-
-Popover.defaultProps = {
-  closeOnBlur: true,
-  closeOnEsc: false,
-  closeOnInnerClick: false,
-  closeOnOuterClick: false,
-  placement: 'bottom-start',
-  modifiers: [],
 };
 
 Popover.displayName = 'Popover';

--- a/src/Popover/Popover.tsx
+++ b/src/Popover/Popover.tsx
@@ -43,4 +43,4 @@ Popover.defaultProps = {
 
 Popover.displayName = 'Popover';
 
-export { Popover as UncontrolledPopover };
+export { Popover };

--- a/src/Popover/Popover.tsx
+++ b/src/Popover/Popover.tsx
@@ -4,7 +4,7 @@ import { Modifier, usePopper } from 'react-popper';
 import { Box } from '../Box';
 import { useKeyPress } from '../hooks';
 
-export type Offset = [skidding?: number, distance?: number];
+export type Offset = [number, number];
 
 export interface PopoverProps {
   /** Trigger element for the popover. */

--- a/src/Popover/Popover.tsx
+++ b/src/Popover/Popover.tsx
@@ -1,0 +1,46 @@
+import { Placement } from '@popperjs/core';
+import * as React from 'react';
+import { usePopper } from 'react-popper';
+import styled from 'styled-components';
+
+const Trigger = styled('div')`
+  display: inline-flex;
+`;
+
+const Container = styled('div')``;
+
+export interface PopoverProps {
+  trigger: React.ReactElement;
+  children: React.ReactElement;
+  placement?: Placement;
+}
+
+const Popover: React.FC<PopoverProps> = ({ trigger, children, placement }) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const referenceEl = React.useRef<HTMLDivElement>(null);
+  const popperEl = React.useRef<HTMLDivElement>(null);
+
+  const { attributes, styles } = usePopper(referenceEl.current, popperEl.current, { placement });
+
+  return (
+    <>
+      <Trigger ref={referenceEl}>
+        {React.cloneElement(trigger, {
+          onClick: () => setIsOpen((prev) => !prev),
+        })}
+      </Trigger>
+      <Container ref={popperEl} style={styles.popper} {...attributes.popper}>
+        {isOpen && <>{children}</>}
+      </Container>
+    </>
+  );
+};
+
+Popover.defaultProps = {
+  placement: 'bottom-start',
+};
+
+Popover.displayName = 'Popover';
+
+export { Popover as UncontrolledPopover };

--- a/src/Popover/index.ts
+++ b/src/Popover/index.ts
@@ -1,0 +1,1 @@
+export * from './Popover';

--- a/src/Stack/Stack.tsx
+++ b/src/Stack/Stack.tsx
@@ -15,8 +15,8 @@ export interface StackProps extends FlexProps {
 const Stack: React.FC<StackProps> = ({
   children,
   direction: directionProp,
-  isReversed: isReversedProp,
-  orientation,
+  isReversed: isReversedProp = false,
+  orientation = 'vertical',
   spacing,
   ...rest
 }) => {
@@ -53,11 +53,6 @@ const Stack: React.FC<StackProps> = ({
       })}
     </Flex>
   );
-};
-
-Stack.defaultProps = {
-  isReversed: false,
-  orientation: 'vertical',
 };
 
 Stack.displayName = 'Stack';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ export * from './Heading';
 export * from './hooks';
 export * from './Input';
 export * from './Link';
+export * from './Menu';
 export * from './Modal';
 export * from './Overlay';
 export * from './Popover';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 import * as util from './util';
 
+export * from './Avatar';
 export * from './Box';
 export * from './Button';
 export * from './ColorModeProvider';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ export * from './Input';
 export * from './Link';
 export * from './Modal';
 export * from './Overlay';
+export * from './Popover';
 export * from './Portal';
 export * from './Select';
 export * from './SpicyProvider';

--- a/src/system/components/Avatar.ts
+++ b/src/system/components/Avatar.ts
@@ -8,6 +8,7 @@ export const Avatar: ComponentTheme = {
     borderRadius: 'full',
     fontWeight: 'medium',
     overflow: 'hidden',
+    userSelect: 'none',
   }),
   sizes: {
     xs: () => ({

--- a/src/system/components/Avatar.ts
+++ b/src/system/components/Avatar.ts
@@ -1,0 +1,34 @@
+import { ComponentTheme } from '../types';
+
+export const Avatar: ComponentTheme = {
+  baseStyle: () => ({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 'full',
+    fontWeight: 'medium',
+    overflow: 'hidden',
+  }),
+  sizes: {
+    xs: () => ({
+      width: 6,
+      height: 6,
+      fontSize: 'xs',
+    }),
+    sm: () => ({
+      width: 8,
+      height: 8,
+      fontSize: 'sm',
+    }),
+    md: () => ({
+      width: 10,
+      height: 10,
+      fontSize: 'md',
+    }),
+    lg: () => ({
+      width: 12,
+      height: 12,
+      fontSize: 'lg',
+    }),
+  },
+};

--- a/src/system/components/Avatar.ts
+++ b/src/system/components/Avatar.ts
@@ -30,5 +30,20 @@ export const Avatar: ComponentTheme = {
       height: 12,
       fontSize: 'lg',
     }),
+    xl: () => ({
+      width: 16,
+      height: 16,
+      fontSize: 'xl',
+    }),
+    '2xl': () => ({
+      width: 24,
+      height: 24,
+      fontSize: '2xl',
+    }),
+    '3xl': () => ({
+      width: 32,
+      height: 32,
+      fontSize: '3xl',
+    }),
   },
 };

--- a/src/system/components/Field.ts
+++ b/src/system/components/Field.ts
@@ -26,7 +26,7 @@ const FieldHelperText: ComponentTheme = {
   }),
 };
 
-export const Field = {
+export const FieldComponents = {
   FieldLabel,
   FieldRequired,
   FieldControl,

--- a/src/system/components/Heading.ts
+++ b/src/system/components/Heading.ts
@@ -2,6 +2,8 @@ import { ComponentTheme } from '../types';
 
 export const Heading: ComponentTheme = {
   baseStyle: () => ({
+    m: 0,
+    p: 0,
     fontFamily: 'heading',
     fontWeight: 'normal',
     lineHeight: 'tightest',

--- a/src/system/components/Menu.ts
+++ b/src/system/components/Menu.ts
@@ -53,7 +53,7 @@ const MenuDivider: ComponentTheme = {
 };
 
 const MenuHeader: ComponentTheme = {
-  baseStyle: (props: any) => ({
+  baseStyle: () => ({
     mx: '4',
     my: '2',
     flex: '1 1 auto',

--- a/src/system/components/Menu.ts
+++ b/src/system/components/Menu.ts
@@ -1,0 +1,72 @@
+import { transparentize } from 'polished';
+import { get } from 'styled-system';
+import { colorMode } from '../../util';
+import { ComponentTheme } from '../types';
+
+const Menu: ComponentTheme = {
+  baseStyle: (props: any) => ({
+    minWidth: '56',
+    display: 'flex',
+    flexDirection: 'column',
+    border: '1px',
+    borderColor: transparentize(0.6, get(props.theme.colors, colorMode('gray.300', 'gray.600')(props))),
+    borderRadius: 'sm',
+    boxShadow: 'sm',
+  }),
+};
+
+const MenuItem: ComponentTheme = {
+  baseStyle: (props: any) => ({
+    px: '4',
+    minHeight: '10',
+    flex: '1 1 auto',
+    display: 'flex',
+    alignItems: 'center',
+    appearance: 'none',
+    background: 'none',
+    backgroundColor: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    outline: 'none',
+    textAlign: 'left',
+    transitionProperty: get(props.theme, 'transitions.property.common'),
+    transitionDuration: get(props.theme, 'transitions.duration.300'),
+    transitionTimingFunction: get(props.theme, 'transitions.timing.inOut'),
+    ':not(:disabled):hover': {
+      bg: transparentize(0.8, get(props.theme.colors, 'gray.100')),
+    },
+    ':active': {
+      bg: transparentize(0.7, get(props.theme.colors, 'gray.100')),
+    },
+  }),
+};
+
+const MenuDivider: ComponentTheme = {
+  baseStyle: (props: any) => ({
+    width: 'auto',
+    border: 0,
+    borderBottom: '1px solid',
+    borderColor: 'inherit',
+    color: colorMode('gray.300', 'gray.600')(props),
+    opacity: 0.6,
+  }),
+};
+
+const MenuHeader: ComponentTheme = {
+  baseStyle: (props: any) => ({
+    mx: '4',
+    my: '2',
+    flex: '1 1 auto',
+    display: 'flex',
+    alignItems: 'center',
+    fontSize: 'sm',
+    fontWeight: 'semibold',
+  }),
+};
+
+export const MenuComponents = {
+  Menu,
+  MenuItem,
+  MenuDivider,
+  MenuHeader,
+};

--- a/src/system/components/index.ts
+++ b/src/system/components/index.ts
@@ -2,10 +2,11 @@ import { Avatar } from './Avatar';
 import { Button } from './Button';
 import { Divider } from './Divider';
 import { Drawer } from './Drawer';
-import { Field } from './Field';
+import { FieldComponents } from './Field';
 import { Heading } from './Heading';
 import { Input } from './Input';
 import { Link } from './Link';
+import { MenuComponents } from './Menu';
 import { Modal } from './Modal';
 import { Overlay } from './Overlay';
 import { Select } from './Select';
@@ -17,10 +18,11 @@ export const components = {
   Button,
   Divider,
   Drawer,
-  ...Field,
+  ...FieldComponents,
   Heading,
-  Link,
   Input,
+  Link,
+  ...MenuComponents,
   Modal,
   Overlay,
   Select,

--- a/src/system/components/index.ts
+++ b/src/system/components/index.ts
@@ -1,3 +1,4 @@
+import { Avatar } from './Avatar';
 import { Button } from './Button';
 import { Divider } from './Divider';
 import { Drawer } from './Drawer';
@@ -12,6 +13,7 @@ import { Text } from './Text';
 import { TextArea } from './TextArea';
 
 export const components = {
+  Avatar,
   Button,
   Divider,
   Drawer,

--- a/src/system/foundations/shadows.ts
+++ b/src/system/foundations/shadows.ts
@@ -3,13 +3,11 @@ import { colors } from './colors';
 
 export const shadows = {
   none: 'none',
-  xs: '0 0 0 1px rgba(0, 0, 0, 0.05)',
-  sm: '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
-  md: '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
-  lg: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
-  xl: '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
-  '2xl': '0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)',
-  '3xl': '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+  xs: '0 0 0 1px rgba(0, 0, 0, 0.15)',
+  sm: '0px 2px 6px rgba(0, 0, 0, 0.15)',
+  md: '0px 6px 12px rgba(0, 0, 0, 0.15)',
+  lg: '0px 12px 24px rgba(0, 0, 0, 0.15)',
+  xl: '0px 24px 48px rgba(0, 0, 0, 0.15)',
   inner: 'inset 0 2px 4px 0 rgba(0, 0, 0, 0.06)',
   outline: `0 0 0 3px ${rgba(colors.blue[500], 0.5)}`,
   warning: `0 0 0 3px ${rgba(colors.orange[500], 0.5)}`,

--- a/src/util/withColorMode.ts
+++ b/src/util/withColorMode.ts
@@ -1,5 +1,6 @@
 import { useColorMode } from '../ColorModeProvider';
 
+// eslint-disable-next-line @typescript-eslint/ban-types
 export const withColorMode = (fn: Function) => (p: any) => {
   const { colorMode } = useColorMode();
   return fn({ ...p, colorMode });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4987,7 +4987,7 @@ csstype@^2.5.7:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.13.tgz#a6893015b90e84dd6e85d0e3b442a1e84f2dbe0f"
   integrity sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==
 
-csstype@^3.0.2:
+csstype@^3.0.2, csstype@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.4.tgz#b156d7be03b84ff425c9a0a4b1e5f4da9c5ca888"
   integrity sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1528,6 +1528,11 @@
   dependencies:
     mkdirp "^1.0.4"
 
+"@popperjs/core@^2.5.3":
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.3.tgz#4982b0b66b7a4cf949b86f5d25a8cf757d3cfd9d"
+  integrity sha512-RFwCobxsvZ6j7twS7dHIZQZituMIDJJNHS/qY6iuthVebxS3zhRY+jaC2roEKiAYaVuTcGmX6Luc6YBcf6zJVg==
+
 "@reach/router@^1.3.3":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"
@@ -10357,7 +10362,7 @@ react-error-overlay@^6.0.7:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.8.tgz#474ed11d04fc6bda3af643447d85e9127ed6b5de"
   integrity sha512-HvPuUQnLp5H7TouGq3kzBeioJmXms1wHy9EGjz2OURWBp4qZO6AfGEcnxts1D/CbwPLRAgTMPCEgYhA3sEM4vw==
 
-react-fast-compare@^3.2.0:
+react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
@@ -10442,6 +10447,14 @@ react-popper@^1.3.7:
     popper.js "^1.14.4"
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
+    warning "^4.0.2"
+
+react-popper@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.3.tgz#33d425fa6975d4bd54d9acd64897a89d904b9d97"
+  integrity sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==
+  dependencies:
+    react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
 react-select@^3.0.8:


### PR DESCRIPTION
## Description

- Adds `Avatar` component
- Adds `Popover` component
- Adds `Menu` component
- Improvements to `box shadows` steps in theme
- Fix for headers receiving default browser margin/padding
- Renamed `Drawer` and `Modal` props

### To do

- [x] Popover
  - [x] Close popover on focus lost (prop?)
  - [x] Escape key to close popover (prop?)
  - [x] Optional focus trap inside popover
- [x] Menu components
  - [x] MenuWrapper
  - [x] Item
  - [x] Divider
  - [x] Header?

### Related Issues

- n/a
