### PR TITLE
0.1.0-alpha.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
 
 -->
 
+## 0.1.0-alpha.7 (9 June, 2021)
+
+### Changes
+
+- Changed `HTMLAttributes` prop interface to extend `React.HTMLAttributes` instead of `React.AllHTMLAttributes`
+
 ## 0.1.0-alpha.6 (8 June, 2021)
 
 ### Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@spicy-ui/core",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spicy-ui/core",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "A themable and extensible React UI library, ready to use out of the box",
   "keywords": [
     "react",

--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { allSystem, sxMixin } from '../../system';
 import { BoxProps } from '../Box';
 
-export interface FlexProps extends Omit<BoxProps, 'wrap'>, ExtendedFlexboxProps {}
+export interface FlexProps extends BoxProps, ExtendedFlexboxProps {}
 
 export const Flex = styled.div.withConfig<FlexProps>({ shouldForwardProp })(sxMixin, allSystem, extendedFlexbox);
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -88,7 +88,7 @@ export type SelectSizes = 'xs' | 'sm' | 'md' | 'lg';
 
 export type SelectVariants = 'outlined' | 'filled' | 'underlined' | 'unstyled';
 
-export interface SelectProps extends Omit<HTMLAttributes, 'onChange' | 'value'> {
+export interface SelectProps extends Omit<HTMLAttributes, 'onChange'> {
   searchValue?: string;
   onSearchChange?: (search: string) => void;
   items: SelectItem[];

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -34,7 +34,7 @@ function responsive(prop: any, mapper: (val: any) => any) {
   return null;
 }
 
-export interface StackProps extends Omit<HTMLAttributes, 'wrap'>, ExtendedFlexboxProps, AsProp, ChildrenProp, SxProp {
+export interface StackProps extends HTMLAttributes, ExtendedFlexboxProps, AsProp, ChildrenProp, SxProp {
   /** Spacing between each stack element. */
   spacing?: SpaceProps['margin'];
   /** Set a custom divider element. */

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -10,7 +10,7 @@ export type TagSizes = 'sm' | 'md' | 'lg';
 
 export type TagVariants = 'outline' | 'solid' | 'subtle';
 
-export interface TagProps extends Omit<HTMLAttributes, 'label'>, AsProp, ChildrenProp, SxProp {
+export interface TagProps extends HTMLAttributes, AsProp, ChildrenProp, SxProp {
   /** Label shown within the tag. */
   label?: React.ReactNode;
   /** If `true`, the tag will be rounded. */

--- a/src/components/Tag/TagLabel.tsx
+++ b/src/components/Tag/TagLabel.tsx
@@ -3,7 +3,7 @@ import { SxProp, useComponentStyles } from '../../system';
 import { AsProp, ChildrenProp, HTMLAttributes } from '../../types';
 import { Box } from '../Box';
 
-export interface TagLabelProps extends Omit<HTMLAttributes, 'label'>, AsProp, ChildrenProp, SxProp {
+export interface TagLabelProps extends HTMLAttributes, AsProp, ChildrenProp, SxProp {
   label?: React.ReactNode;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,5 +8,4 @@ export interface ChildrenProp {
   children?: React.ReactNode;
 }
 
-export interface HTMLAttributes<T = HTMLElement>
-  extends Omit<React.AllHTMLAttributes<T>, 'as' | 'height' | 'width' | 'size'> {}
+export interface HTMLAttributes<T = HTMLElement> extends React.HTMLAttributes<T> {}


### PR DESCRIPTION
## Description

- Changed `HTMLAttributes` prop interface to extend `React.HTMLAttributes` instead of `React.AllHTMLAttributes`